### PR TITLE
J0 addreaction&readtime

### DIFF
--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -33,24 +33,26 @@ namespace Tabloid_Fullstack.Controllers
             return Ok(posts);
         }
 
-        [HttpGet("{id}")]
-        public IActionResult GetById(int id)
-        {
-            var post = _repo.GetById(id);
-            if (post == null)
-            {
-                return NotFound();
-            }
-            var comments = _commentRepo.GetCommentsByPostId(id);
-            var reactionCounts = _repo.GetReactionCounts(id);
-            var postDetails = new PostDetails()
-            {
-                Post = post,
-                ReactionCounts = reactionCounts,
-                Comments = comments
-            };
-            return Ok(postDetails);
-        }
+        //[HttpGet("{id}")]
+        //public IActionResult GetById(int id)
+        //{
+        //    var post = _repo.GetById(id);
+        //    if (post == null)
+        //    {
+        //        return NotFound();
+        //    }
+        //    var comments = _commentRepo.GetCommentsByPostId(id);
+        //    var reactionCounts = _repo.GetReactionCounts(id);
+        //    var postDetails = new PostDetails()
+        //    var postReactions = 
+        //    {
+        //        Post = post,
+        //        ReactionCounts = reactionCounts,
+        //        Comments = comments,
+        //        PostReaction =
+        //    };
+        //    return Ok(postDetails);
+        //}
 
         [HttpGet("mypost")]
         public IActionResult GetMyPost()

--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -69,6 +69,14 @@ namespace Tabloid_Fullstack.Controllers
             return CreatedAtAction("Get", new { id = post.Id }, post);
         }
 
+        [HttpPost("/addReaction")]
+        public IActionResult AddReaction(PostReaction postReaction)
+        {
+            postReaction.UserProfileId = GetCurrentUserProfile().Id;
+            _repo.AddReaction(postReaction);
+            return CreatedAtAction("Get", new { id = postReaction.Id }, postReaction);
+        }
+
         [HttpPut("mypost/{id}")]
         public IActionResult Put(int id, Post post)
         {

--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -33,26 +33,26 @@ namespace Tabloid_Fullstack.Controllers
             return Ok(posts);
         }
 
-        //[HttpGet("{id}")]
-        //public IActionResult GetById(int id)
-        //{
-        //    var post = _repo.GetById(id);
-        //    if (post == null)
-        //    {
-        //        return NotFound();
-        //    }
-        //    var comments = _commentRepo.GetCommentsByPostId(id);
-        //    var reactionCounts = _repo.GetReactionCounts(id);
-        //    var postDetails = new PostDetails()
-        //    var postReactions = 
-        //    {
-        //        Post = post,
-        //        ReactionCounts = reactionCounts,
-        //        Comments = comments,
-        //        PostReaction =
-        //    };
-        //    return Ok(postDetails);
-        //}
+        [HttpGet("{id}")]
+        public IActionResult GetById(int id)
+        {
+            var post = _repo.GetById(id);
+            if (post == null)
+            {
+                return NotFound();
+            }
+            var comments = _commentRepo.GetCommentsByPostId(id);
+            var reactionCounts = _repo.GetReactionCounts(id);
+            var postReactions = _repo.GetPostReactionsByPost(id);
+            var postDetails = new PostDetails()
+            {
+                Post = post,
+                ReactionCounts = reactionCounts,
+                Comments = comments,
+                PostReactions = postReactions
+            };
+            return Ok(postDetails);
+        }
 
         [HttpGet("mypost")]
         public IActionResult GetMyPost()

--- a/Tabloid-Fullstack/Controllers/PostController.cs
+++ b/Tabloid-Fullstack/Controllers/PostController.cs
@@ -71,7 +71,7 @@ namespace Tabloid_Fullstack.Controllers
             return CreatedAtAction("Get", new { id = post.Id }, post);
         }
 
-        [HttpPost("/addReaction")]
+        [HttpPost("addreaction")]
         public IActionResult AddReaction(PostReaction postReaction)
         {
             postReaction.UserProfileId = GetCurrentUserProfile().Id;

--- a/Tabloid-Fullstack/Models/PostReaction.cs
+++ b/Tabloid-Fullstack/Models/PostReaction.cs
@@ -12,5 +12,7 @@ namespace Tabloid_Fullstack.Models
         public Post Post { get; set; }
         public int ReactionId { get; set; }
         public Reaction Reaction { get; set; }
+
+        public int UserProfileId { get; set; }
     }
 }

--- a/Tabloid-Fullstack/Models/PostReaction.cs
+++ b/Tabloid-Fullstack/Models/PostReaction.cs
@@ -12,7 +12,6 @@ namespace Tabloid_Fullstack.Models
         public Post Post { get; set; }
         public int ReactionId { get; set; }
         public Reaction Reaction { get; set; }
-
         public int UserProfileId { get; set; }
 
 

--- a/Tabloid-Fullstack/Models/PostReaction.cs
+++ b/Tabloid-Fullstack/Models/PostReaction.cs
@@ -14,5 +14,7 @@ namespace Tabloid_Fullstack.Models
         public Reaction Reaction { get; set; }
 
         public int UserProfileId { get; set; }
+
+
     }
 }

--- a/Tabloid-Fullstack/Models/ViewModels/PostDetails.cs
+++ b/Tabloid-Fullstack/Models/ViewModels/PostDetails.cs
@@ -11,6 +11,7 @@ namespace Tabloid_Fullstack.Models.ViewModels
         public List<ReactionCount> ReactionCounts { get; set; }
         public List<Comment> Comments { get; set; }
         
+        public List<PostReaction> PostReactions { get; set; } 
 
     }
 }

--- a/Tabloid-Fullstack/Repositories/IPostRepository.cs
+++ b/Tabloid-Fullstack/Repositories/IPostRepository.cs
@@ -14,5 +14,6 @@ namespace Tabloid_Fullstack.Repositories
         void Delete(int id);
         List<Post> GetByUserId(int id);
         void AddReaction(PostReaction postReaction);
+        List<PostReaction> GetPostReactionsByPost(int postId);
     }
 }

--- a/Tabloid-Fullstack/Repositories/IPostRepository.cs
+++ b/Tabloid-Fullstack/Repositories/IPostRepository.cs
@@ -13,5 +13,6 @@ namespace Tabloid_Fullstack.Repositories
         void Update(Post post);
         void Delete(int id);
         List<Post> GetByUserId(int id);
+        void AddReaction(PostReaction postReaction);
     }
 }

--- a/Tabloid-Fullstack/Repositories/PostRepository.cs
+++ b/Tabloid-Fullstack/Repositories/PostRepository.cs
@@ -73,9 +73,22 @@ namespace Tabloid_Fullstack.Repositories
                 .ToList();
         }
 
+        public List<PostReaction> GetPostReactionsByPost(int postId)
+        {
+            return _context.PostReaction
+                .Where(pr => pr.PostId == postId)
+                .ToList();
+        }
+
         public void Add(Post post)
         {
             _context.Add(post);
+            _context.SaveChanges();
+        }
+
+        public void AddReaction(PostReaction postReaction)
+        {
+            _context.Add(postReaction);
             _context.SaveChanges();
         }
 

--- a/Tabloid-Fullstack/client/src/components/Comments/CommentForm.js
+++ b/Tabloid-Fullstack/client/src/components/Comments/CommentForm.js
@@ -48,10 +48,7 @@ export const CommentForm = ({ commentToEdit, getPost, cancelEdit }) => {
                     },
                     body: JSON.stringify({ id: commentToEdit.id, subject: subject, content: content, userProfileId: user.id }),
                 })
-            }).then(() => {
-                // cancelEdit();
-                getPost();
-            })
+            }).then(() => getPost())
 
     }
     const submit = (e) => {

--- a/Tabloid-Fullstack/client/src/components/PostReactions.js
+++ b/Tabloid-Fullstack/client/src/components/PostReactions.js
@@ -1,8 +1,20 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Badge } from "reactstrap";
+import { useParams } from "react-router-dom";
 import "./PostReaction.css";
 
-const PostReactions = ({ postReactions }) => {
+const PostReactions = ({ postReactions, getPost }) => {
+  const [hasReacted, setHasReacted] = useState(false)
+  const { postId } = useParams()
+  const addReaction = () => { }
+
+  useEffect(() => {
+    console.log('postReactions', postReactions)
+    // if(postReactions)
+
+
+  }, [])
+
   return (
     <div className="float-left">
       {postReactions.map((postReaction) => (

--- a/Tabloid-Fullstack/client/src/components/PostReactions.js
+++ b/Tabloid-Fullstack/client/src/components/PostReactions.js
@@ -1,12 +1,35 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useContext } from "react";
 import { Badge } from "reactstrap";
 import { useParams } from "react-router-dom";
 import "./PostReaction.css";
+import { UserProfileContext } from "../providers/UserProfileProvider";
 
 const PostReactions = ({ postReactions, getPost }) => {
+  const { getCurrentUser, getToken } = useContext(UserProfileContext)
   const [hasReacted, setHasReacted] = useState(false)
   const { postId } = useParams()
-  const addReaction = () => { }
+  const user = getCurrentUser();
+
+
+  const addReaction = (e) => {
+    console.log(e)
+    let postReactionObj = {
+      postId,
+      userProfileId: user.id,
+      ReactionId: e.target.id
+    }
+    return getToken().then((token) => {
+      fetch('/api/post/addreaction', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(postReactionObj)
+      })
+    }).then(() => getPost())
+
+  }
 
   useEffect(() => {
     console.log('postReactions', postReactions)
@@ -15,14 +38,18 @@ const PostReactions = ({ postReactions, getPost }) => {
 
   }, [])
 
+
+
   return (
     <div className="float-left">
       {postReactions.map((postReaction) => (
         <div key={postReaction.reaction.id} className="d-inline-block mx-2">
           <Badge
             pill
+            id={postReaction.reaction.id}
             className="p-2 border border-dark post-reaction__pill"
             title={postReaction.reaction.name}
+            onClick={addReaction}
           >
             {postReaction.reaction.emoji} {postReaction.count}
           </Badge>

--- a/Tabloid-Fullstack/client/src/pages/PostDetails.js
+++ b/Tabloid-Fullstack/client/src/pages/PostDetails.js
@@ -61,7 +61,7 @@ const PostDetails = () => {
         <div className="text-justify post-details__content">{post.content}</div>
 
         <div className="my-4">
-          <PostReactions postReactions={reactionCounts} />
+          <PostReactions postReactions={reactionCounts} getPost={getPost} />
         </div>
         {comments ?
           <div className="col float-left my-4 text-left">

--- a/Tabloid-Fullstack/client/src/pages/PostDetails.js
+++ b/Tabloid-Fullstack/client/src/pages/PostDetails.js
@@ -15,7 +15,7 @@ const PostDetails = () => {
   const [comments, setComments] = useState([]);
 
   const getPost = () => {
-    fetch(`/api/post/${postId}`)
+    return fetch(`/api/post/${postId}`)
       .then((res) => {
         if (res.status === 404) {
           toast.error("This isn't the post you're looking for");
@@ -24,6 +24,7 @@ const PostDetails = () => {
         return res.json();
       })
       .then((data) => {
+        console.log(data)
         setPost(data.post);
         setReactionCounts(data.reactionCounts);
         setComments(data.comments)


### PR DESCRIPTION
Posts on the explore view should now have an estimated read time.
users can add reactions to posts
-look for read times on the explore page
- go on a post detail page and click one of the reactions to add.
- as per the ticket you can (for now ) react as many times as you want 